### PR TITLE
Package fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,7 @@
         "react-native-screens": "~3.22.0",
         "react-native-svg": "^6.2.1",
         "react-native-svg-charts": "^5.4.0",
-        "react-native-web": "~0.19.6",
-        "typescript": "^5.2.2"
+        "react-native-web": "~0.19.6"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -19152,6 +19151,8 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "react-native-screens": "~3.22.0",
     "react-native-svg": "^6.2.1",
     "react-native-svg-charts": "^5.4.0",
-    "react-native-web": "~0.19.6",
-    "typescript": "^5.2.2"
+    "react-native-web": "~0.19.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
Downgraded react-native-svg package to 6.2.1, and removed react-native-svg-transformer